### PR TITLE
Execute the commands before loading the module.

### DIFF
--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -208,7 +208,7 @@ namespace BCI2000RemoteNET
             return true;
         }
 
-        public virtual bool Connect(string[] commandsInProgDir) //Connects to operator module, starts operator if not running
+        public virtual bool Connect() //Connects to operator module, starts operator if not running
         {
             
             if (String.IsNullOrEmpty(TelnetIp))
@@ -275,12 +275,9 @@ namespace BCI2000RemoteNET
 
             WindowTitle = windowTitle;
             WindowVisible = windowVisible;
-            
+
             Execute("change directory $BCI2000LAUNCHDIR");
-            foreach (string command in commandsInProgDir)
-            {
-                Execute(command);
-            }
+
             return true;
         }
         public bool Execute(string command)

--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -208,7 +208,7 @@ namespace BCI2000RemoteNET
             return true;
         }
 
-        public virtual bool Connect() //Connects to operator module, starts operator if not running
+        public virtual bool Connect(string[] commandsInProgDir) //Connects to operator module, starts operator if not running
         {
             
             if (String.IsNullOrEmpty(TelnetIp))
@@ -275,9 +275,12 @@ namespace BCI2000RemoteNET
 
             WindowTitle = windowTitle;
             WindowVisible = windowVisible;
-
+            
             Execute("change directory $BCI2000LAUNCHDIR");
-
+            foreach (string command in commandsInProgDir)
+            {
+                Execute(command);
+            }
             return true;
         }
         public bool Execute(string command)

--- a/BCI2000Remote.cs
+++ b/BCI2000Remote.cs
@@ -91,9 +91,9 @@ namespace BCI2000RemoteNET
                 Disconnect();
         }
 
-        public override bool Connect()
+        public override bool Connect(string[] commandsInProgDir)
         {
-            bool success = base.Connect();
+            bool success = base.Connect(commandsInProgDir);
             if (success)
             {
                 if (!String.IsNullOrEmpty(SubjectID))

--- a/BCI2000Remote.cs
+++ b/BCI2000Remote.cs
@@ -91,9 +91,18 @@ namespace BCI2000RemoteNET
                 Disconnect();
         }
 
-        public override bool Connect(string[] commandsInProgDir)
+        public bool Connect(string[] commandsInProgDir)
         {
-            bool success = base.Connect(commandsInProgDir);
+            bool success = Connect();
+            foreach (string command in commandsInProgDir)
+            {
+                Execute(command);
+            }
+            return success;
+        }
+        public override bool Connect()
+        {
+            bool success = base.Connect();
             if (success)
             {
                 if (!String.IsNullOrEmpty(SubjectID))


### PR DESCRIPTION
For example, to link UnityBCI2000 and BCPy2000 (Python), the commands must be executed before loading the module.

```bat
#! ../prog/BCI2000Shell
@cls & ..\prog\BCI2000Shell %0 %* #! && exit /b 0 || exit /b 1\n


execute script FindPortablePython.bat  # this is necessary so that BCI2000 can find Python # <--- this


change directory $BCI2000LAUNCHDIR
show window; set title ${Extract file base $0}
reset system
startup system localhost
start executable SignalGenerator --local
start executable PythonSignalProcessing --local --PythonSigClassFile=file.py --PythonSigShell=0 --PythonSigLog=Siglogger.txt
start executable DummyApplication      --local
wait for connected 600

```
I supported this. 

---

UnityBCI2000 displays it this way.

![2023-05-16 125803](https://github.com/neurotechcenter/BCI2000RemoteNET/assets/72431055/17714b3f-e841-4cdf-a816-ad85bf0a5622)

I am also sending a pull request to https://github.com/neurotechcenter/UnityBCI2000/pull/5 .
