### PR TITLE
Fixed response freeze and implemented generic parsing in .NET standard 2.1

### DIFF
--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -241,27 +241,21 @@ namespace BCI2000RemoteNET {
 	//Gets the response from the operator and attempts to parse into the given type
 	private T GetResponseAs<T>() {
 	    string response = ReceiveResponse();
-	    try {
-		if (typeof(T) == typeof(string))
+		
+		if (typeof(T) == typeof(string)) {
 			return (T)(object)response;
-		return ParseResponse<T>(response);
-	    } catch (Exception ex) {
-		throw new BCI2000CommandException($"Could not parse response {response} as type {nameof(T)}, {ex}");
-	    }
-	}
+		}
 
-	//Parses response if given type has a Parse(string) method
-	private T ParseResponse<T>(string response)
-	{
-		try {
+	    try {
 		MethodInfo parseMethod = typeof(T).GetMethod("Parse", new Type[] {typeof(string)});
 		if (parseMethod is not null) {
 			return (T)parseMethod.Invoke(null, new object[] {response});
 		}
-		throw new BCI2000CommandException($"Parsing of response type {nameof(T)} is unsupported");
-		} catch (Exception ex) {
-		throw new BCI2000CommandException($"Could not parse response {response} as type {nameof(T)}, {ex}");
-		}
+	    } catch (Exception ex) {
+		throw new BCI2000CommandException($"Failed to parse response {response} as type {nameof(T)}, {ex}");
+	    }
+
+		throw new BCI2000CommandException($"Response parsing unsupported for type {nameof(T)}");
 	}
 
 	//Receives response from operator and throws if response is not blank. Used with commands which expect no response, such as setting events and parameters.

--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -25,6 +25,8 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 
+#nullable enable
+
 namespace BCI2000RemoteNET {
     /// <summary>
     ///Provides basic functionality for connection and communication with the BCI2000 operator module.

--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -277,10 +277,10 @@ namespace BCI2000RemoteNET {
 	private string ReceiveResponse() {
 	    StringBuilder response = new StringBuilder();
 			bool receiving = true;
-			float startTime = DateTime.UtcNow.Millisecond;
+			long startTime = GetSystemTime();
 			while (receiving)
 			{
-				float elapsedTime = DateTime.UtcNow.Millisecond - startTime;
+				long elapsedTime = GetSystemTime() - startTime;
 				if (elapsedTime > Timeout)
 				{
 					throw new TimeoutException();
@@ -340,6 +340,11 @@ namespace BCI2000RemoteNET {
             }
 			return true;
 		}
+
+	private long GetSystemTime()
+	{
+		return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+	}	
 
 	private TcpClient? connection;
 	private NetworkStream? op_stream;

--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -186,7 +186,7 @@ namespace BCI2000RemoteNET {
 	/// </summary>
 	/// <returns>Whether or not this object is currently connected to BCI2000</returns>
 	public bool Connected() {
-	    return connection?.Connected ?? false;
+	    return connection?.IsConnected() ?? false;
 	}
 
 	/// <summary>
@@ -280,6 +280,12 @@ namespace BCI2000RemoteNET {
 			long startTime = GetSystemTime();
 			while (receiving)
 			{
+				if (!Connected()) {
+					throw new BCI2000ConnectionException(
+						"Lost connection while receiving response"
+					);
+				}
+
 				long elapsedTime = GetSystemTime() - startTime;
 				if (elapsedTime > Timeout)
 				{

--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 
@@ -240,8 +241,8 @@ namespace BCI2000RemoteNET {
 	    string response = ReceiveResponse();
 	    try {
 		if (typeof(T) == typeof(string))
-			return response;
-		return ParseResponse(response);
+			return (T)(object)response;
+		return ParseResponse<T>(response);
 	    } catch (Exception ex) {
 		throw new BCI2000CommandException($"Could not parse response {response} as type {nameof(T)}, {ex}");
 	    }

--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -266,8 +266,15 @@ namespace BCI2000RemoteNET {
 	private string ReceiveResponse() {
 	    StringBuilder response = new StringBuilder();
 			bool receiving = true;
+			float startTime = DateTime.UtcNow.Millisecond;
 			while (receiving)
 			{
+				float elapsedTime = DateTime.UtcNow.Millisecond - startTime;
+				if (elapsedTime > Timeout)
+				{
+					throw new TimeoutException();
+				}
+
 				if (!op_stream!.DataAvailable)
 				{
 					continue;

--- a/BCI2000Connection.cs
+++ b/BCI2000Connection.cs
@@ -287,7 +287,7 @@ namespace BCI2000RemoteNET {
 				}
 
 				long elapsedTime = GetSystemTime() - startTime;
-				if (elapsedTime > Timeout)
+				if (Timeout > 0 && elapsedTime > Timeout)
 				{
 					throw new TimeoutException();
 				}

--- a/BCI2000Remote.cs
+++ b/BCI2000Remote.cs
@@ -72,7 +72,7 @@ namespace BCI2000RemoteNET {
 		connection.Execute($"start executable {mod_name} {args_str ?? " --local"}");
 	    }
 
-	    WaitForSystemState([SystemState.Connected, SystemState.Initialization]);
+	    WaitForSystemState(new[] {SystemState.Connected, SystemState.Initialization});
 	    remoteState = RemoteState.Connected;
 	}
 
@@ -220,7 +220,7 @@ namespace BCI2000RemoteNET {
 	/// <param name="minValue">The minimum value of the parameter. This argument is optional.</param>
 	/// <exception cref="BCI2000CommandException">Thrown if BCI2000 is in an invalid state for adding parameters</exception>
 	public void AddParameter(string section, string name, string defaultValue = "%", string minValue = "%", string maxValue = "%") {
-	    var containsWS = ((string[])[section, name, defaultValue, minValue, maxValue]).Where(str => str.Any(Char.IsWhiteSpace)).Select(str => $"\"{str}\""); 
+	    var containsWS = (new []{section, name, defaultValue, minValue, maxValue}).Where(str => str.Any(Char.IsWhiteSpace)).Select(str => $"\"{str}\""); 
 	    if (containsWS.Count() != 0) {
 		throw new BCI2000CommandException($"Parameter definition parameters must not contain whitespace. Parameter(s) {string.Join(',', containsWS)} contain whitespace.");
 	    }

--- a/BCI2000Remote.cs
+++ b/BCI2000Remote.cs
@@ -23,6 +23,8 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 
+#nullable enable
+
 namespace BCI2000RemoteNET {
     /// <summary>
     ///Provides functionality for control of BCI2000.

--- a/NetworkExtensions.cs
+++ b/NetworkExtensions.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace BCI2000 {
+    public class NetworkExtensions {
+        public static bool IsConnected(this TcpClient client) {
+            return client.GetState() is not (
+                TcpState.Unknown or TcpState.Closed or
+                TcpState.Closing or TcpState.CloseWait
+            );
+        }
+
+        public static TcpState GetState(this TcpClient client) {
+            TcpConnectionInformation matchingConnection
+            = IPGlobalProperties.GetIPGlobalProperties()
+                .GetActiveTcpConnections()
+                .SingleOrDefault(x => x.LocalEndPoint.Equals(
+                    client.Client.LocalEndPoint
+                    )
+                );
+            return matchingConnection?.State ?? TcpState.Unknown;
+        }
+    }
+}


### PR DESCRIPTION
*fixed version of #4*
- implemented timeout in `ReadResponse`, which would hang in an infinite loop waiting for available data if a command was executed expecting a reply after the connection was terminated *(close BCI2000 operator with remote application still open)*
  - *The TcpClient doesn't seem to register as closed until an operation has failed?*
- implemented generic response parsing compatible with .NET standard 2.1 by fetching a `Parse` method from the type itself
